### PR TITLE
Fix SAI Editor navigation to show enhanced version

### DIFF
--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -144,7 +144,7 @@ export default function HomePage() {
       name: "SAI Editor",
       icon: Workflow,
       description: "Visual Smart AI script builder",
-      href: "/sai-editor",
+      href: "/sai-editor-enhanced",
       color: "text-blue-400",
     },
     {

--- a/web-ui/components/Navigation.tsx
+++ b/web-ui/components/Navigation.tsx
@@ -48,7 +48,7 @@ const navigation: NavItem[] = [
   // Development Tools
   { label: "Schema Explorer", href: "/schema-explorer", icon: <Database className="w-4 h-4" />, category: "tools" },
   { label: "AI Visualizer", href: "/ai-visualizer", icon: <Activity className="w-4 h-4" />, category: "tools" },
-  { label: "SAI Editor", href: "/sai-editor", icon: <FileCode className="w-4 h-4" />, category: "tools" },
+  { label: "SAI Editor", href: "/sai-editor-enhanced", icon: <FileCode className="w-4 h-4" />, category: "tools" },
   { label: "Map Picker", href: "/map-picker", icon: <Globe className="w-4 h-4" />, category: "tools" },
   { label: "3D Viewer", href: "/3d-viewer", icon: <Layers className="w-4 h-4" />, category: "tools" },
 


### PR DESCRIPTION
## Summary

Fixed navigation links that were pointing to the basic SAI editor instead of the enhanced version with all the improvements.

### Changes Made
- Updated `web-ui/components/Navigation.tsx` to link to `/sai-editor-enhanced`
- Updated `web-ui/app/page.tsx` homepage card to link to `/sai-editor-enhanced`

### Problem
The enhanced SAI editor page was created at `/sai-editor-enhanced/page.tsx` with professional features, but the navigation menu and homepage were still pointing to the basic version at `/sai-editor`, making the enhancements invisible to users.

### Solution
Redirected all SAI Editor navigation links to the enhanced version which includes:
- Full parameter editing with detailed input controls
- Real-time script validation with errors/warnings
- AI-powered suggestions for actions and targets
- Undo/Redo functionality (Ctrl+Z/Ctrl+Y)
- Copy/Paste support (Ctrl+C/Ctrl+V)
- Auto-layout for organizing nodes
- Custom node types with professional styling
- Property editor panel with three tabs
- Script metadata editing
- Template library
- SQL and JSON export

## Test Plan
- [ ] Navigate to the SAI Editor from the main navigation menu
- [ ] Verify the enhanced editor loads (should see three-panel layout)
- [ ] Navigate to the SAI Editor from the homepage cards
- [ ] Verify all enhanced features are accessible
- [ ] Test adding event, action, and target nodes
- [ ] Test the property editor panel on the right side
- [ ] Test validation, suggestions, and export functionality